### PR TITLE
Added pyserial to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         'opencv-python',
         'mediapipe',
         'numpy',
+        'pyserial',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Added 'pyserial' to install_requires in the setup.py file to fix the error arising from SerialModule.py after installing it locally.