### PR TITLE
[BUGFIX] FACE_CONNECTIONS no longer exists in mp

### DIFF
--- a/cvzone/FaceMeshModule.py
+++ b/cvzone/FaceMeshModule.py
@@ -45,7 +45,7 @@ class FaceMeshDetector:
         if self.results.multi_face_landmarks:
             for faceLms in self.results.multi_face_landmarks:
                 if draw:
-                    self.mpDraw.draw_landmarks(img, faceLms, self.mpFaceMesh.FACE_CONNECTIONS,
+                    self.mpDraw.draw_landmarks(img, faceLms, self.mpFaceMesh.FACEMESH_CONTOURS,
                                                self.drawSpec, self.drawSpec)
                 face = []
                 for id, lm in enumerate(faceLms.landmark):


### PR DESCRIPTION
FACE_CONNECTIONS no longer exists, I recommend using FACEMESH_CONTOURS to get the outlines of the face. 

https://github.com/google/mediapipe/blob/master/mediapipe/python/solutions/face_mesh_connections.py